### PR TITLE
fix: 외래키 NOT NULL 제약 조건 추가

### DIFF
--- a/src/main/java/uss/code/cart/entity/Cart.java
+++ b/src/main/java/uss/code/cart/entity/Cart.java
@@ -24,11 +24,11 @@ public class Cart {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(nullable = false, name = "member_id")
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "course_id")
+    @JoinColumn(nullable = false,name = "course_id")
     private Course course;
 
     @Column(nullable = false, name = "created_at")

--- a/src/main/java/uss/code/challengeCode/entity/ChallengeCode.java
+++ b/src/main/java/uss/code/challengeCode/entity/ChallengeCode.java
@@ -16,7 +16,7 @@ public class ChallengeCode {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
+    @JoinColumn( nullable = false, name = "member_id")
     private Member member;
 
     @Column(nullable = false)

--- a/src/main/java/uss/code/course/entity/CourseSchedule.java
+++ b/src/main/java/uss/code/course/entity/CourseSchedule.java
@@ -17,7 +17,7 @@ public class CourseSchedule {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "course_id")
+    @JoinColumn(nullable = false, name = "course_id")
     private Course course;
 
     @Column(nullable = false, name = "schedule_text")

--- a/src/main/java/uss/code/registration/entity/Registration.java
+++ b/src/main/java/uss/code/registration/entity/Registration.java
@@ -24,11 +24,11 @@ public class Registration {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(nullable = false, name = "member_id")
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "course_id")
+    @JoinColumn(nullable = false, name = "course_id")
     private Course course;
 
     @Column(nullable = false, name = "created_at")


### PR DESCRIPTION
## 🧑🏻‍💻 이슈 번호
- close #1 

## ✅ 구현 사항
- 코드레빗 피드백을 반영하여, @JoinColumn에 nullable = false 제약 조건을 추가하였습니다.
- 코드레빗 피드백 중, @ManyToOne 어노테이션의 optional = false 옵션을 추가하라는 부분도 있었지만, 이는 반영하지 않았습니다. 해당 옵션을 추가하면, Lazy로 설정되어 있는 로딩 전략이 무효되어 프록시 객체가 아닌 실제 객체가 로딩되기 때문에 추가하지 않았습니다.

## 🤔 추가 고려 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 카트, 등록, 강좌 등 주요 데이터베이스 엔티티의 관계 제약 조건을 강화했습니다. 이 변경을 통해 데이터 무결성이 개선되고 시스템 안정성이 향상됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->