### PR TITLE
fix: 요청 파라메터 최대 길이 수정

### DIFF
--- a/src/main/java/uss/code/course/controller/CourseController.java
+++ b/src/main/java/uss/code/course/controller/CourseController.java
@@ -38,7 +38,7 @@ public class CourseController implements CourseControllerDocs {
 
     @GetMapping("/other-department")
     public ResponseEntity<MajorCoursesResponse> getOtherDepartmentCourses(
-            @ParamValidation(maxLength = 30)
+            @ParamValidation(maxLength = 40)
             @RequestParam("department") final String department
     ){
         return ResponseEntity.ok(courseService.getOtherDepartmentCourses(department));
@@ -46,7 +46,7 @@ public class CourseController implements CourseControllerDocs {
 
     @GetMapping("/interdisciplinary-major")
     public ResponseEntity<InterdisciplinaryMajorCoursesResponse> getInterdisciplinaryMajorCourses(
-            @ParamValidation(maxLength = 30)
+            @ParamValidation(maxLength = 40)
             @RequestParam("department") final String department
     ){
         return ResponseEntity.ok(courseService.getInterdisciplinaryMajorCourses(department));
@@ -54,7 +54,7 @@ public class CourseController implements CourseControllerDocs {
 
     @GetMapping("/search")
     public ResponseEntity<SearchedCoursesResponse> searchCourses(
-            @ParamValidation(maxLength = 30)
+            @ParamValidation(maxLength = 70)
             @RequestParam("keyword") final String keyword
     ){
         return ResponseEntity.ok(courseService.searchCourses(keyword.trim()));

--- a/src/main/java/uss/code/global/config/P6SpyConfig.java
+++ b/src/main/java/uss/code/global/config/P6SpyConfig.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class P6SpyConfig {
-
     @PostConstruct
     public void setLogMessageFormat() {
         P6SpyOptions.getActiveInstance()

--- a/src/main/java/uss/code/global/config/P6SpySqlFormatter.java
+++ b/src/main/java/uss/code/global/config/P6SpySqlFormatter.java
@@ -7,7 +7,6 @@ import org.hibernate.engine.jdbc.internal.FormatStyle;
 import java.util.Locale;
 
 public class P6SpySqlFormatter implements MessageFormattingStrategy {
-
     @Override
     public String formatMessage(
             final int connectionId,


### PR DESCRIPTION
## 🧑🏻‍💻 이슈 번호
- close #38 

## ✅ 구현 사항
기존 30으로 고정되어 있던 입력 파라메터의 길이 제한을 기대하는 열거형 타입의 최대 길이의 첫째자리 올림값으로 수정하였습니다.

## 🤔 추가 고려 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 검색 기능의 키워드 입력 길이 제한을 70자로 확대
  * 강좌 필터(교과 영역, 부서)의 입력 길이 제한을 40자로 확대

* **스타일**
  * 코드 포맷팅 정리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->